### PR TITLE
Output the carry flag to C

### DIFF
--- a/arch/ps4/syscall_arch.h
+++ b/arch/ps4/syscall_arch.h
@@ -4,133 +4,112 @@
 static __inline long __syscall0(long n)
 {
 	unsigned long ret;
+	char iserror;
 
 	__asm__ __volatile__
 	(
-		".intel_syntax\n\t"
-		"syscall\n\t"
-		"jnc syscallexit%=\n\t"
-		"neg rax\n\t"
-		"syscallexit%=:\n\t" : "=a"(ret) :
-                                       "a"(n) :
-                                       "rcx", "r8", "r9", "r10", "r11", "memory"
+		"syscall" : "=a"(ret), "=@ccc"(iserror) :
+                            "a"(n) :
+                            "rcx", "r8", "r9", "r10", "r11", "memory"
 	);
 
-	return ret;
+	return iserror ? -ret : ret;
 }
 
 static __inline long __syscall1(long n, long a1)
 {
 	unsigned long ret;
+	char iserror;
 
 	__asm__ __volatile__
 	(
-		".intel_syntax\n\t"
-		"syscall\n\t"
-		"jnc syscallexit%=\n\t"
-		"neg rax\n\t"
-		"syscallexit%=:\n\t" : "=a"(ret) :
-                                       "a"(n), "D"(a1) :
-                                       "rcx", "r8", "r9", "r10", "r11", "memory"
+		"syscall" : "=a"(ret), "=@ccc"(iserror) :
+                            "a"(n), "D"(a1) :
+                            "rcx", "r8", "r9", "r10", "r11", "memory"
 	);
 
-	return ret;
+	return iserror ? -ret : ret;
 }
 
 static __inline long __syscall2(long n, long a1, long a2)
 {
 	unsigned long ret;
+	char iserror;
 
 	__asm__ __volatile__
 	(
-		".intel_syntax\n\t"
-		"syscall\n\t"
-		"jnc syscallexit%=\n\t"
-		"neg rax\n\t"
-		"syscallexit%=:\n\t" : "=a"(ret) :
-                                       "a"(n), "D"(a1), "S"(a2) :
-                                       "rcx", "r8", "r9", "r10", "r11", "memory"
+		"syscall" : "=a"(ret), "=@ccc"(iserror) :
+                            "a"(n), "D"(a1), "S"(a2) :
+                            "rcx", "r8", "r9", "r10", "r11", "memory"
 	);
 
-	return ret;
+	return iserror ? -ret : ret;
 }
 
 static __inline long __syscall3(long n, long a1, long a2, long a3)
 {
 	unsigned long ret;
+	char iserror;
 
 	__asm__ __volatile__
 	(
-		".intel_syntax\n\t"
-		"syscall\n\t"
-		"jnc syscallexit%=\n\t"
-		"neg rax\n\t"
-		"syscallexit%=:\n\t" : "=a"(ret) :
-                                       "a"(n), "D"(a1), "S"(a2), "d"(a3) :
-                                       "rcx", "r8", "r9", "r10", "r11", "memory"
+		"syscall" : "=a"(ret), "=@ccc"(iserror) :
+                            "a"(n), "D"(a1), "S"(a2), "d"(a3) :
+                            "rcx", "r8", "r9", "r10", "r11", "memory"
 	);
 
-	return ret;
+	return iserror ? -ret : ret;
 }
 
 static __inline long __syscall4(long n, long a1, long a2, long a3, long a4)
 {
 	unsigned long ret;
+	char iserror;
 	register long r10 __asm__("r10") = a4;
 	
 	__asm__ __volatile__
 	(
-		".intel_syntax\n\t"
-		"syscall\n\t"
-		"jnc syscallexit%=\n\t"
-		"neg rax\n\t"
-		"syscallexit%=:\n\t" : "=a"(ret), "+r"(r10) :
-                                       "a"(n), "D"(a1), "S"(a2), "d"(a3) :
-                                       "rcx", "r8", "r9", "r11", "memory"
+		"syscall" : "=a"(ret), "=@ccc"(iserror), "+r"(r10) :
+                            "a"(n), "D"(a1), "S"(a2), "d"(a3) :
+                            "rcx", "r8", "r9", "r11", "memory"
 	);
 
-	return ret;
+	return iserror ? -ret : ret;
 }
 
 static __inline long __syscall5(long n, long a1, long a2, long a3, long a4, long a5)
 {
 	unsigned long ret;
+	char iserror;
 	register long r10 __asm__("r10") = a4;
 	register long r8 __asm__("r8") = a5;
 
 	__asm__ __volatile__
 	(
-		".intel_syntax\n\t"
-		"syscall\n\t"
-		"jnc syscallexit%=\n\t"
-		"neg rax\n\t"
-		"syscallexit%=:\n\t" : "=a"(ret), "+r"(r10), "+r"(r8) :
-                                       "a"(n), "D"(a1), "S"(a2), "d"(a3) :
-                                       "rcx", "r9", "r11", "memory"
+		"syscall" : "=a"(ret), "=@ccc"(iserror), "+r"(r10), "+r"(r8) :
+                            "a"(n), "D"(a1), "S"(a2), "d"(a3) :
+                            "rcx", "r9", "r11", "memory"
 	);
 
-	return ret;
+	return iserror ? -ret : ret;
 }
 
 static __inline long __syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6)
 {
 	unsigned long ret;
+	char iserror;
 	register long r10 __asm__("r10") = a4;
 	register long r8 __asm__("r8") = a5;
 	register long r9 __asm__("r9") = a6;
 
 	__asm__ __volatile__
 	(
-		".intel_syntax\n\t"
-		"syscall\n\t"
-		"jnc syscallexit%=\n\t"
-		"neg rax\n\t"
-		"syscallexit%=:\n\t" : "=a"(ret), "+r"(r10), "+r"(r8), "+r"(r9) :
-                                       "a"(n), "D"(a1), "S"(a2), "d"(a3) :
-                                       "rcx", "r11", "memory"
+		"syscall" : "=a"(ret), "=@ccc"(iserror), "+r"(r10), "+r"(r8), "+r"(r9) :
+                            "a"(n), "D"(a1), "S"(a2), "d"(a3) :
+                            "rcx", "r11", "memory"
 	);
 
-	return ret;
+	return iserror ? -ret : ret;
 }
 
 #define VDSO_USEFUL


### PR DESCRIPTION
Instead of jumping and maybe negating `ret` in assembly, pass the carry flag as an output parameter, and do the negation in C if necessary. This will enable better codegen in places that these get inlined.