### PR TITLE
Store current locale in a TLS variable

### DIFF
--- a/arch/ps4/crt_arch.h
+++ b/arch/ps4/crt_arch.h
@@ -25,6 +25,7 @@ START ": \n"
 "mov r11d, eax \n"
 "mov edi, r11d \n"
 "call exit \n"
+".att_syntax prefix \n"
 );*/
 
 // sceLibcParam
@@ -53,6 +54,7 @@ __asm__(
 "	.quad 	0 \n"
 "	.quad	0 \n"
 "	.quad 	0 \n"
+".att_syntax prefix \n"
 );
 
 // sceKernelMemParam
@@ -68,6 +70,7 @@ __asm__(
 "	.quad 	0 \n"
 "	.quad 	0 \n"
 "	.quad 	0 \n"
+".att_syntax prefix \n"
 );
 
 // sceKernelFsParam
@@ -79,6 +82,7 @@ __asm__(
 	// size
 "	.quad 	0x10 \n"
 "	.quad 	0 \n"
+".att_syntax prefix \n"
 );
 
 // sceLibcMallocReplace
@@ -102,6 +106,7 @@ __asm__(
 "	.quad 	0 \n"
 "	.quad 	0 \n"
 "	.quad 	0 \n"
+".att_syntax prefix \n"
 );
 
 // sceLibcNewReplace
@@ -125,6 +130,7 @@ __asm__(
 "	.quad 	0 \n"
 "	.quad 	0 \n"
 "	.quad 	0 \n"
+".att_syntax prefix \n"
 );
 
 // sceLibcMallocReplaceForTls
@@ -141,6 +147,7 @@ __asm__(
 "	.quad 	0 \n"
 "	.quad 	0 \n"
 "	.quad 	0 \n"
+".att_syntax prefix \n"
 );
 
 // sce_process_param
@@ -164,6 +171,7 @@ __asm__(
 "	.quad 	_sceLibcParam \n"
 "	.quad 	_sceKernelMemParam \n"
 "	.quad 	_sceKernelFsParam \n"
+".att_syntax prefix \n"
 );
 
 // data globals
@@ -183,5 +191,6 @@ __asm__(
 "	.quad 	0 \n"
 "_sceLibc: \n"
 "	.quad 	0 \n"
+".att_syntax prefix \n"
 );
 

--- a/src/env/__init_tls.c
+++ b/src/env/__init_tls.c
@@ -13,6 +13,7 @@ volatile int __thread_list_lock;
 
 int __init_tp(void *p)
 {
+#ifndef PS4
 	pthread_t td = p;
 	td->self = td;
 	int r = __set_thread_area(TP_ADJ(p));
@@ -24,6 +25,7 @@ int __init_tp(void *p)
 	td->robust_list.head = &td->robust_list.head;
 	td->sysinfo = __sysinfo;
 	td->next = td->prev = td;
+#endif
 	return 0;
 }
 

--- a/src/internal/locale_impl.h
+++ b/src/internal/locale_impl.h
@@ -35,9 +35,17 @@ hidden char *__gettextdomain(void);
 #define C_LOCALE ((locale_t)&__c_locale)
 #define UTF8_LOCALE ((locale_t)&__c_dot_utf8_locale)
 
+#ifndef PS4
 #define CURRENT_LOCALE (__pthread_self()->locale)
+#else
+#define CURRENT_LOCALE (*({\
+    if(!__musl_current_locale)\
+        __musl_current_locale = &libc.global_locale;\
+    &__musl_current_locale;\
+}))
+#endif
 
-#define CURRENT_UTF8 (!!__pthread_self()->locale->cat[LC_CTYPE])
+#define CURRENT_UTF8 (!!CURRENT_LOCALE->cat[LC_CTYPE])
 
 #undef MB_CUR_MAX
 #define MB_CUR_MAX (CURRENT_UTF8 ? 4 : 1)

--- a/src/internal/pthread_impl.h
+++ b/src/internal/pthread_impl.h
@@ -44,7 +44,9 @@ struct pthread {
 		volatile void *volatile pending;
 	} robust_list;
 	volatile int timer_id;
+#ifndef PS4
 	locale_t locale;
+#endif
 	volatile int killlock[1];
 	char *dlerror_buf;
 	void *stdio_locks;
@@ -54,6 +56,10 @@ struct pthread {
 	uintptr_t canary_at_end;
 	uintptr_t *dtv_copy;
 };
+
+#ifdef PS4
+extern __thread locale_t __musl_current_locale;
+#endif
 
 enum {
 	DT_EXITING = 0,

--- a/src/locale/uselocale.c
+++ b/src/locale/uselocale.c
@@ -4,11 +4,10 @@
 
 locale_t __uselocale(locale_t new)
 {
-	pthread_t self = __pthread_self();
-	locale_t old = self->locale;
+	locale_t old = CURRENT_LOCALE;
 	locale_t global = &libc.global_locale;
 
-	if (new) self->locale = new == LC_GLOBAL_LOCALE ? global : new;
+	if (new) CURRENT_LOCALE = new == LC_GLOBAL_LOCALE ? global : new;
 
 	return old == global ? LC_GLOBAL_LOCALE : old;
 }

--- a/src/thread/ps4/musl_current_locale.c
+++ b/src/thread/ps4/musl_current_locale.c
@@ -1,0 +1,3 @@
+#include "locale_impl.h"
+
+__thread locale_t __musl_current_locale;


### PR DESCRIPTION
Musl was storing the current locale for a thread in a field of `struct pthread`. As we don't control the layout of `struct pthread` on PS4, it has to be stored in a different place.

Fixes [mbstowcs issue](https://github.com/OpenOrbis/OpenOrbis-PS4-Toolchain/issues/84). Depends on the [TLS fix](https://github.com/OpenOrbis/OpenOrbis-PS4-Toolchain/pull/87).