### PR TITLE
Fix dynamic resolver (getaddrinfo et al.)

### DIFF
--- a/include/netinet/in.h
+++ b/include/netinet/in.h
@@ -15,7 +15,7 @@ struct in_addr { in_addr_t s_addr; };
 
 struct sockaddr_in {
 	uint8_t sin_len;
-	sa_family_t sin_family;
+	uint8_t sin_family;
 	in_port_t sin_port;
 	struct in_addr sin_addr;
 	uint8_t sin_zero[8];

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -92,8 +92,8 @@ struct linger {
 #define SOCK_PACKET    10
 
 #ifndef SOCK_CLOEXEC
-#define SOCK_CLOEXEC   02000000
-#define SOCK_NONBLOCK  04000
+#define SOCK_CLOEXEC   0 // ps4
+#define SOCK_NONBLOCK  0 // ps4
 #endif
 
 #define PF_UNSPEC       0
@@ -365,7 +365,8 @@ struct linger {
 #define SCM_CREDENTIALS 0x02
 
 struct sockaddr {
-	sa_family_t sa_family;
+	unsigned char sa_len;
+	unsigned char sa_family;
 	char sa_data[14];
 };
 

--- a/src/network/res_msend.c
+++ b/src/network/res_msend.c
@@ -56,6 +56,7 @@ int __res_msend_rc(int nqueries, const unsigned char *const *queries,
 		const struct address *iplit = &conf->ns[nns];
 		if (iplit->family == AF_INET) {
 			memcpy(&ns[nns].sin.sin_addr, iplit->addr, 4);
+			ns[nns].sin.sin_len = 0;
 			ns[nns].sin.sin_port = htons(53);
 			ns[nns].sin.sin_family = AF_INET;
 		} else {
@@ -136,6 +137,7 @@ int __res_msend_rc(int nqueries, const unsigned char *const *queries,
 			if (rlen < 4) continue;
 
 			/* Ignore replies from addresses we didn't send to */
+			sa.sin.sin_len = 0;
 			for (j=0; j<nns && memcmp(ns+j, &sa, sl); j++);
 			if (j==nns) continue;
 


### PR DESCRIPTION
* retrieve DNS server addresses using `sceNetGetDnsInfo`
* fix `struct sockaddr` in musl-internal headers
* pthread fix

Please review before merging.