### PR TITLE
use SYS_lstat syscall that matches with current def of 'struct stat'

### DIFF
--- a/arch/ps4/bits/syscall.h.in
+++ b/arch/ps4/bits/syscall.h.in
@@ -123,7 +123,7 @@
 #define	__NR_setgid	181
 #define	__NR_setegid	182
 #define	__NR_seteuid	183
-#define	__NR_stat	188
+//#define __NR_stat 188  //available and working, but uses old 'struct stat'
 #define	__NR_fstat	189
 #define	__NR_lstat	190
 #define	__NR_pathconf	191


### PR DESCRIPTION
musl will use the SYS_lstat if SYS_stat is not defined. The SYS_stat syscall  is working fine on the PS4, but expects and older version of 'struct stat' (available in recent versions of freebsd under the name 'struct ostat')

struct ostat is defined at: https://github.com/freebsd/freebsd-src/blob/098dbd7ff7f3da9dda03802cdb2d8755f816eada/sys/sys/stat.h#L105