### PR TITLE
Fix CRT for proper argv parsing

### DIFF
--- a/arch/ps4/crt_arch.h
+++ b/arch/ps4/crt_arch.h
@@ -1,4 +1,4 @@
-__asm__(
+/*__asm__(
 ".text \n"
 ".global " START " \n"
 START ": \n"
@@ -9,6 +9,13 @@ START ": \n"
 "	lea _DYNAMIC(%rip),%rsi \n"
 "	andq $-16,%rsp \n"
 "	call " START "_ps4_c \n"
+);*/
+
+__asm__(
+".text \n"
+".global " START " \n"
+START ": \n"
+"   jmp " START "_ps4_c \n"
 );
 
 /*__asm__(


### PR DESCRIPTION
See [here](https://github.com/freebsd/freebsd-src/blob/release/9.0.0/sys/amd64/amd64/machdep.c#L896) for why this is correct.