### PR TITLE
Add ENOTRECOVERABLE and EOWNERDEAD

### DIFF
--- a/arch/ps4/bits/errno.h
+++ b/arch/ps4/bits/errno.h
@@ -124,3 +124,19 @@
 #define	EMULTIHOP	90		/* Multihop attempted */
 #define	ENOLINK		91		/* Link has been severed */
 #define	EPROTO		92		/* Protocol error */
+
+#ifndef _POSIX_SOURCE
+#define	ENOTCAPABLE	93		/* Capabilities insufficient */
+#define	ECAPMODE	94		/* Not permitted in capability mode */
+
+/* These 3 are not yet present in FreeBSD version 9, but declaring them won't hurt, and will make for less patches in consumers. */
+#define	ENOTRECOVERABLE	95		/* State not recoverable */
+#define	EOWNERDEAD	96		/* Previous owner died */
+#define	EINTEGRITY	97		/* Integrity check failed */
+
+#endif /* _POSIX_SOURCE */
+
+#ifndef _POSIX_SOURCE
+#define	ELAST		97		/* Must be equal largest errno */
+#endif /* _POSIX_SOURCE */
+

--- a/src/errno/__strerror.h
+++ b/src/errno/__strerror.h
@@ -61,10 +61,8 @@ E(EMLINK,       "Too many links")
 E(ENOLCK,       "No locks available")
 
 E(EDEADLK,      "Resource deadlock would occur")
-#ifndef PS4
 E(ENOTRECOVERABLE, "State not recoverable")
 E(EOWNERDEAD,   "Previous owner died")
-#endif
 E(ECANCELED,    "Operation canceled")
 E(ENOSYS,       "Function not implemented")
 E(ENOMSG,       "No message of desired type")


### PR DESCRIPTION
Although these were added in later FreeBSD versions, libcxx does reference them in
their include files. I think it's easier to put them here than to patch LLVM, and
adding error codes that just never get returned does not hurt.

FreeBSD 9 does not seem to support robust mutexes, so any code expecting these errno values would break anyway.