### PR TITLE
Fix d_fileno define

### DIFF
--- a/include/dirent.h
+++ b/include/dirent.h
@@ -19,7 +19,7 @@ extern "C" {
 
 typedef struct __dirstream DIR;
 
-#define d_fileno d_ino
+#define d_ino d_fileno
 
 int            closedir(DIR *);
 DIR           *fdopendir(int);


### PR DESCRIPTION
```
./Modules/posixmodule.c:16389:65: error: no member named 'd_ino' in 'struct dirent'
 16389 |                                              name_len, direntp->d_ino
       |                                                        ~~~~~~~  ^
1 warning and 1 error generated.
```
```
./Modules/posixmodule.c:16389:65: error: no member named 'd_ino' in 'struct dirent'
 16389 |                                              name_len, direntp->d_fileno
       |                                                        ~~~~~~~  ^
/media/kalaposfos/Shared/shadps4/dev-homebrew/toolchain-18-git/include/dirent.h:22:18: note: expanded from macro 'd_fileno'
   22 | #define d_fileno d_ino
      |                  ^
1 warning and 1 error generated.
```
With this change, both will work.